### PR TITLE
[css-pseudo] Implement parsing for ::marker pseudo-element

### DIFF
--- a/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html
+++ b/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: Parsing tree-abiding pseudo-elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#treelike">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<meta name="assert" content="This test checks that gutters adjacent to collapsed tracks don't reduce the space available for aligning adjacent grid items." />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+// Generated content pseudo-elements
+test_valid_selector("::before");
+test_valid_selector("*::before", "::before");
+test_valid_selector("foo.bar[baz]::before");
+test_invalid_selector("::before *");
+
+test_valid_selector("::after");
+test_valid_selector("*::after", "::after");
+test_valid_selector("foo.bar[baz]::after");
+test_invalid_selector("::after *");
+
+// List marker pseudo-element
+test_valid_selector("::marker");
+test_valid_selector("*::marker", "::marker");
+test_valid_selector("foo.bar[baz]::marker");
+test_invalid_selector("::marker *");
+
+// Placeholder input pseudo-element
+test_valid_selector("::placeholder");
+test_valid_selector("*::placeholder", "::placeholder");
+test_valid_selector("foo.bar[baz]::placeholder");
+test_invalid_selector("::placeholder *");
+
+// Combinations of the above
+test_invalid_selector("::before::before");
+test_invalid_selector("::after::before");
+test_invalid_selector("::marker::before");
+test_invalid_selector("::placeholder::before");
+
+test_invalid_selector("::before::after");
+test_invalid_selector("::after::after");
+test_invalid_selector("::marker::after");
+test_invalid_selector("::placeholder::after");
+
+test_valid_selector("::before::marker");
+test_valid_selector("::after::marker");
+test_invalid_selector("::marker::marker");
+test_invalid_selector("::placeholder::marker");
+
+test_invalid_selector("::before::placeholder");
+test_invalid_selector("::after::placeholder");
+test_invalid_selector("::marker::placeholder");
+test_invalid_selector("::placeholder::placeholder");
+</script>

--- a/css/css-scoping/slotted-parsing.html
+++ b/css/css-scoping/slotted-parsing.html
@@ -5,31 +5,10 @@
 <link rel="help" href="https://drafts.csswg.org/css-scoping/#slotted-pseudo">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
 <style id="styleElm">
 </style>
 <script>
-  function parse_selector(selector_text) {
-    try {
-      styleElm.sheet.insertRule(selector_text+"{}");
-      styleElm.sheet.deleteRule(0);
-      return true;
-    } catch (ex) {
-      return false;
-    }
-  }
-
-  function test_valid_selector(selector_text) {
-    test(function(){
-      assert_true(parse_selector(selector_text));
-    }, "Should be a valid selector: '" + selector_text + "'");
-  }
-
-  function test_invalid_selector(selector_text) {
-    test(function(){
-      assert_false(parse_selector(selector_text));
-    }, "Should be an invalid selector: '" + selector_text + "'");
-  }
-
   test_invalid_selector("::slotted");
   test_invalid_selector("::slotted()");
   test_invalid_selector("::slotted(*).class");

--- a/css/support/parsing-testcommon.js
+++ b/css/support/parsing-testcommon.js
@@ -36,3 +36,62 @@ function test_invalid_value(property, value) {
         assert_equals(div.style.getPropertyValue(property), "");
     }, "e.style['" + property + "'] = " + stringifiedValue + " should not set the property value");
 }
+
+// serializedSelector can be the expected serialization of selector,
+// or an array of permitted serializations,
+// or omitted if value should serialize as selector.
+function test_valid_selector(selector, serializedSelector) {
+    if (arguments.length < 2)
+        serializedSelector = selector;
+
+    const stringifiedSelector = JSON.stringify(selector);
+
+    test(function(){
+        document.querySelector(selector);
+        assert_true(true, stringifiedSelector + " should not throw in querySelector");
+
+        const style = document.createElement("style");
+        document.head.append(style);
+        const {sheet} = style;
+        document.head.removeChild(style);
+        const {cssRules} = sheet;
+
+        assert_equals(cssRules.length, 0, "Sheet should have no rule");
+        sheet.insertRule(selector + "{}");
+        assert_equals(cssRules.length, 1, "Sheet should have 1 rule");
+
+        const readSelector = cssRules[0].selectorText;
+        if (Array.isArray(serializedSelector))
+            assert_in_array(readSelector, serializedSelector, "serialization should be sound");
+        else
+            assert_equals(readSelector, serializedSelector, "serialization should be canonical");
+
+        sheet.deleteRule(0);
+        assert_equals(cssRules.length, 0, "Sheet should have no rule");
+        sheet.insertRule(readSelector + "{}");
+        assert_equals(cssRules.length, 1, "Sheet should have 1 rule");
+
+        assert_equals(cssRules[0].selectorText, readSelector, "serialization should round-trip");
+    }, stringifiedSelector + " should be a valid selector");
+}
+
+function test_invalid_selector(selector) {
+    const stringifiedSelector = JSON.stringify(selector);
+
+    test(function(){
+        assert_throws(
+          DOMException.SYNTAX_ERR,
+          () => document.querySelector(selector),
+          stringifiedSelector + " should throw in querySelector");
+
+        const style = document.createElement("style");
+        document.head.append(style);
+        const {sheet} = style;
+        document.head.removeChild(style);
+
+        assert_throws(
+          DOMException.SYNTAX_ERR,
+          () => sheet.insertRule(selector + "{}"),
+          stringifiedSelector + " should throw in insertRule");
+    }, stringifiedSelector + " should be an invalid selector");
+}


### PR DESCRIPTION
Parse ::marker as a valid pseudo-element, behind an experimental flag.
The actual logic of ::marker will be implemented in follow-up patches.

Intent to Implement:
https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/8v7pouXxxAc

Spec: https://drafts.csswg.org/css-pseudo-4/#marker-pseudo

Bug: 457718

TEST=external/wpt/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html
TEST=external/wpt/css/css-scoping/slotted-parsing.html

Change-Id: Ia4014afdbf5d0f2a642f349641140b03dfceee22
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1876407
Commit-Queue: Oriol Brufau <obrufau@igalia.com>
Reviewed-by: Rune Lillesveen <futhark@chromium.org>
Cr-Commit-Position: refs/heads/master@{#709390}